### PR TITLE
Adjust nav menu breakpoints

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -573,7 +573,7 @@ function toggleMenu() {
     const mobileMenuIcon = document.getElementById('mobile-menu-icon');
 
     if (mobileMenu.dataset.hidden === 'true') {
-        mobileMenu.className = 'sm:hidden';
+        mobileMenu.className = 'lg:hidden';
         mobileMenu.dataset.hidden = 'false';
         mobileMenuIcon.className = 'fa-solid fa-x';
     } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,7 +54,7 @@
                 <i class="fa-brands fa-playstation text-3xl"></i>
                 <span class="font-bold text-xl tracking-tight">Y2JB</span>
             </div>
-            <div class="absolute inset-y-0 right-0 flex items-center gap-2 sm:hidden">
+            <div class="absolute inset-y-0 right-0 flex items-center gap-2 lg:hidden">
                 <button onclick="toggleTheme()"
                         class="w-10 h-10 rounded-full flex items-center justify-center transition-all hover:scale-105 active:scale-95">
                     <i id="theme-icon" class="fa-solid fa-moon"></i>
@@ -64,7 +64,7 @@
                     <i class="fa-solid fa-bars" id="mobile-menu-icon"></i>
                 </button>
             </div>
-            <div class="items-center gap-2 hidden sm:flex">
+            <div class="items-center gap-2 hidden lg:flex">
                 <a href="{{ url_for('repo_manager_ui') }}"
                    class="text-xs input-field px-3 py-1.5 rounded-lg border flex items-center gap-2 opacity-60 hover:opacity-100 transition-opacity">
                     <i class="fa-solid fa-gear"></i>


### PR DESCRIPTION
<img width="716" height="69" alt="Screenshot 2026-01-25 221612" src="https://github.com/user-attachments/assets/c6e1b1ef-b82c-49c8-8c0b-ad02d5045b6a" />

Nav menu is squished with the new items, adjusting the breakpoints to make it unsquished.

<img width="962" height="73" alt="Screenshot 2026-01-25 221632" src="https://github.com/user-attachments/assets/6baa678e-6d54-40c7-8a41-fcb85f4469d2" />

<img width="1094" height="51" alt="Screenshot 2026-01-25 222039" src="https://github.com/user-attachments/assets/e18dd33f-24d2-497f-979a-ae201ad00e4b" />
